### PR TITLE
Fix reviewers, split out requested reviewers

### DIFF
--- a/cmd/github/github.go
+++ b/cmd/github/github.go
@@ -6735,7 +6735,7 @@ func (j *DSGitHub) GetModelDataPullRequest(ctx *shared.Ctx, docs []interface{}) 
 						return
 					}
 					contributor := insights.Contributor{
-						Role:   insights.ReviewerRole,
+						Role:   insights.RequestedReviewerRole,
 						Weight: 1.0,
 						Identity: user.UserIdentityObjectBase{
 							ID:         userID,

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/LF-Engineering/dev-analytics-libraries v1.1.28
 	github.com/LF-Engineering/insights-datasource-shared v1.4.3-0.20220314162813-49e8868ac871
-	github.com/LF-Engineering/lfx-event-schema v0.1.11-0.20220315151021-58c32f92f6db
+	github.com/LF-Engineering/lfx-event-schema v0.1.11-0.20220320055605-9c01462354d6
 	github.com/aws/aws-lambda-go v1.28.0
 	github.com/aws/aws-sdk-go v1.42.39
 	github.com/google/go-github/v43 v43.0.0

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/LF-Engineering/lfx-event-schema v0.1.11-0.20220315141947-321c7a802053
 github.com/LF-Engineering/lfx-event-schema v0.1.11-0.20220315141947-321c7a802053/go.mod h1:CfFIZ4mwzo88umf5+KxDQEzqlVkPG7Vx8eLK2oDfWIs=
 github.com/LF-Engineering/lfx-event-schema v0.1.11-0.20220315151021-58c32f92f6db h1:+K3NtHjscidAGLqZ4ld+/lrB6NBswlxD7mcQNsiPFv4=
 github.com/LF-Engineering/lfx-event-schema v0.1.11-0.20220315151021-58c32f92f6db/go.mod h1:CfFIZ4mwzo88umf5+KxDQEzqlVkPG7Vx8eLK2oDfWIs=
+github.com/LF-Engineering/lfx-event-schema v0.1.11-0.20220320055605-9c01462354d6 h1:jCiu4G+ih1ZuMbRVSmugsM/Z90ZuyGs61VPXaUClh8w=
+github.com/LF-Engineering/lfx-event-schema v0.1.11-0.20220320055605-9c01462354d6/go.mod h1:CfFIZ4mwzo88umf5+KxDQEzqlVkPG7Vx8eLK2oDfWIs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/alecthomas/jsonschema v0.0.0-20210920000243-787cd8204a0d/go.mod h1:/n6+1/DWPltRLWL/VKyUxg6tzsl5kHUCcraimt4vr60=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=


### PR DESCRIPTION
cc @fayazg related to https://github.com/LF-Engineering/lfx-event-schema/pull/162

Requested reviewer is not a revierer yet - many repos auto add requested reviewers, so we would false count reviewers.

Signed-off-by: Łukasz Gryglicki <lgryglicki@cncf.io>